### PR TITLE
Make dns_inwx_shared_secret optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ For older Ubuntu distributions check out this PPA: [ppa:certbot/certbot](https:/
 
 2. Configure it with your INWX API Login Details:
 
+   ```
     vim /etc/letsencrypt/inwx.cfg
+   ```
+    
+    Add quotes to your password if it contains characters like '#'.
 
 3. Make sure the file is only readable by root! Otherwise all your domains might be in danger.
 

--- a/certbot_dns_inwx/dns_inwx.py
+++ b/certbot_dns_inwx/dns_inwx.py
@@ -48,8 +48,6 @@ class Authenticator(dns_common.DNSAuthenticator):
                 'url': 'URL of the INWX XML-RPC API to use.',
                 'username': 'Username of the INWX API account.',
                 'password': 'Password of the INWX API account.',
-                'shared_secret': 'Optional shared secret code for the two-factor ' + \
-                                 'authentication assigned to the INWX API account.'
             }
         )
     

--- a/inwx.cfg
+++ b/inwx.cfg
@@ -1,5 +1,5 @@
 certbot_dns_inwx:dns_inwx_url           = https://api.domrobot.com/xmlrpc/
 certbot_dns_inwx:dns_inwx_username      = your_username
-certbot_dns_inwx:dns_inwx_password      = your_password
+certbot_dns_inwx:dns_inwx_password      = "your_password"
 certbot_dns_inwx:dns_inwx_shared_secret = your_shared_secret optional
 


### PR DESCRIPTION
Fixes error:
```
> certbot certonly -a certbot-dns-inwx:dns-inwx -d example.com --agree-tos -m "info@example.com" -n
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator certbot-dns-inwx:dns-inwx, Installer None
Obtaining a new certificate
Performing the following challenges:
dns-01 challenge for example.com
Cleaning up challenges
Missing property in credentials configuration file /etc/letsencrypt/inwx.cfg:
 * Property "certbot_dns_inwx:dns_inwx_shared_secret" not set (should be Optional shared secret code for the two-factor authentication assigned to the INWX API account.).
```
See: https://certbot.eff.org/docs/api/plugins/dns_common.html#certbot.plugins.dns_common.DNSAuthenticator._configure_credentials

Configuration file looked like this:
```
certbot_dns_inwx:dns_inwx_url           = https://api.domrobot.com/xmlrpc/
certbot_dns_inwx:dns_inwx_username      = your_username
certbot_dns_inwx:dns_inwx_password      = "your_password"
certbot_dns_inwx:dns_inwx_shared_secret = 
```

BTW: Thank you for your effort of creating this!