### PR TITLE
Add command line switch to control CNAME lookup behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Before certbot v1.7.0, third plugins needed to be accessed using their plugin na
  --dns-inwx-credentials DNS_INWX_CREDENTIALS
                         Path to INWX account credentials INI file (default:
                         /etc/letsencrypt/inwx.cfg)
+ --dns-inwx-follow-cnames DNS_INWX_FOLLOW_CNAMES
+                        If 'true', the plugin will follow CNAME redirects 
+                        on validation records (default: true)
+                        This command line option is only exposed, if 
+                        dnspython is installed.
 
 ```
 

--- a/certbot_dns_inwx/dns_inwx.py
+++ b/certbot_dns_inwx/dns_inwx.py
@@ -41,6 +41,17 @@ class Authenticator(dns_common.DNSAuthenticator):
         super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=60)
         add('credentials', help=('Path to INWX account credentials INI file'),
             default=cfg_default)
+        
+        try:
+            import dns.exception
+            import dns.resolver
+            import dns.name
+            add('follow-cnames', 
+                help=('If \'true\', the plugin will follow CNAME redirects on validation records'),
+                default='true')
+        except ImportError:
+            pass
+
     
     def more_info(self):
         return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
@@ -70,6 +81,9 @@ class Authenticator(dns_common.DNSAuthenticator):
             import dns.exception
             import dns.resolver
             import dns.name
+
+            if self.conf('follow-cnames') != 'true':
+                return validation_name
         except ImportError:
             return validation_name
             


### PR DESCRIPTION
Needed a quick fix to disable the CNAME lookup behaviour even if dnspython is installed (it's installed because another package on my system depends on it) and this is it.

Let me know if you would merge this, then I will edit the README etc. as well.