### PR TITLE
remove zope

### DIFF
--- a/certbot_dns_inwx/dns_inwx.py
+++ b/certbot_dns_inwx/dns_inwx.py
@@ -2,18 +2,13 @@
 import logging
 import sys
 
-import zope.interface
-
 from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
 
 from .inwx import domrobot, getOTP, prettyprint
 
 logger = logging.getLogger(__name__)
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for INWX DNS API
     

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ cb_required = '0.15'
 
 install_requires = [
     'setuptools>=39.0.1',
-    'zope.interface',
 ]
 
 extras_require = {


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.