### PR TITLE
Add optional usage of ENV variables

### DIFF
--- a/certbot_dns_inwx/_internal/dns_inwx.py
+++ b/certbot_dns_inwx/_internal/dns_inwx.py
@@ -57,17 +57,34 @@ class Authenticator(dns_common.DNSAuthenticator):
             'the INWX XML-RPC DNS API.'
 
     def _setup_credentials(self) -> None:
-        self.credentials = self._configure_credentials(
-            'credentials',
-            'path to INWX XML-RPC account credentials INI file',
-            {
-                'url': 'URL of the INWX XML-RPC API to use.',
-                'username': 'Username of the INWX API account.',
-                'password': 'Password of the INWX API account.',
-                'shared_secret': 'Optional shared secret code for the two-factor ' + \
-                                 'authentication assigned to the INWX API account.'
-            }
-        )
+        env_username = os.environ.get("INWX_USERNAME")
+        env_password = os.environ.get("INWX_PASSWORD")
+        env_url = os.environ.get("INWX_URL")
+        env_secret = os.environ.get("INWX_SHARED_SECRET")
+
+        if env_username and env_password and env_url:
+            class EnvCredentials:
+                def conf(self, key):
+                   return {
+                    "url": env_url,
+                    "username": env_username,
+                    "password": env_password,
+                    "shared_secret": env_secret or "",
+                   }[key]
+            self.credentials = EnvCredentials()
+        else:
+            self.credentials = self._configure_credentials(
+                "credentials",
+                "path to INWX XML-RPC account credentials INI file",
+                {
+                    "url": "URL of the INWX XML-RPC API to use.",
+                    "username": "Username of the INWX API account.",
+                    "password": "Password of the INWX API account.",
+                    "shared_secret": "Optional shared secret code for the two-factor "
+                    + "authentication assigned to the INWX API account.",
+                },
+            )
+
 
     def _follow_cnames(self, domain: str, validation_name: str) -> str:
         """


### PR DESCRIPTION
Allow credentials via environment variables (without requiring a config file)

Currently, the plugin requires a credentials file (inwx.cfg) to be present. we mainly use ansible playbooks distributed on different servers. ENV variables are then added to the runtime. if you enable this in the script, it is much easier to create automations and increase security because you don't have to store the access data in plain text on the server. 

**Changes**
The _setup_credentials method now first checks for the presence of the environment variables INWX_USERNAME, INWX_PASSWORD, and INWX_URL (optionally INWX_SHARED_SECRET).

If all required environment variables are set, the plugin uses them directly and does not attempt to load or validate a credentials file.

If any required environment variable is missing, the plugin falls back to the existing behavior and loads credentials from the file specified by --credentials.

The --credentials argument is still required by Certbot, but the file does not need to exist if all environment variables are set.
You can use `--credentials /dev/null` when ENV variables set.

**Benefits**
Makes the plugin easier to use in CI/CD pipelines, Docker containers, and cloud environments.
Increases flexibility for users who prefer to manage secrets via environment variables.
Maintains full backward compatibility: existing users with a credentials file are unaffected.